### PR TITLE
Make tracemate.conf.in example match the partition count in the README

### DIFF
--- a/src/tm.conf.in
+++ b/src/tm.conf.in
@@ -108,6 +108,26 @@
       <topic name="elastic_apm_error" partition="0" batch_size="100"/>
       <topic name="elastic_apm_span" partition="0" batch_size="2000"/>
       <topic name="tracemate_aggregates" partition="0" batch_size="100"/>
+      <topic name="elastic_apm_metric" partition="1" batch_size="100" read_delay_ms="3000" />
+      <topic name="elastic_apm_transaction" partition="1" batch_size="2000"/>
+      <topic name="elastic_apm_error" partition="1" batch_size="100"/>
+      <topic name="elastic_apm_span" partition="1" batch_size="2000"/>
+      <topic name="tracemate_aggregates" partition="1" batch_size="100"/>
+      <topic name="elastic_apm_metric" partition="2" batch_size="100" read_delay_ms="3000" />
+      <topic name="elastic_apm_transaction" partition="2" batch_size="2000"/>
+      <topic name="elastic_apm_error" partition="2" batch_size="100"/>
+      <topic name="elastic_apm_span" partition="2" batch_size="2000"/>
+      <topic name="tracemate_aggregates" partition="2" batch_size="100"/>
+      <topic name="elastic_apm_metric" partition="3" batch_size="100" read_delay_ms="3000" />
+      <topic name="elastic_apm_transaction" partition="3" batch_size="2000"/>
+      <topic name="elastic_apm_error" partition="3" batch_size="100"/>
+      <topic name="elastic_apm_span" partition="3" batch_size="2000"/>
+      <topic name="tracemate_aggregates" partition="3" batch_size="100"/>
+      <topic name="elastic_apm_metric" partition="4" batch_size="100" read_delay_ms="3000" />
+      <topic name="elastic_apm_transaction" partition="4" batch_size="2000"/>
+      <topic name="elastic_apm_error" partition="4" batch_size="100"/>
+      <topic name="elastic_apm_span" partition="4" batch_size="2000"/>
+      <topic name="tracemate_aggregates" partition="4" batch_size="100"/>
     </topics>
   </kafka>
 


### PR DESCRIPTION
Tracemate needs to use the same number of partitions as are defined for your Elastic APM server and in creating the Kafka topics. This is shown in the above comment block, but it was easy to overlook, leading to only a subset of traces being processed. I think making the example config file match the example in the README for kafka will make it easier for people to get things running the first time.